### PR TITLE
Chapter 6

### DIFF
--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -88,7 +88,6 @@ pub const Lexer = struct {
     fn run(self: Self, source: str) !void {
         var scanner = Scanner.init(self.allocator, source);
         defer scanner.deinit();
-        std.log.info("Source: {s}", .{source});
 
         const tokens = try scanner.scanTokens();
         std.log.info("Tokens: {s}", .{tokens.items});

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -95,8 +95,6 @@ pub const Lexer = struct {
         var parser = Parser.init(self.allocator, tokens);
         defer parser.deinit();
         const expr = try parser.parse();
-
-        std.log.info("Before expr.", .{});
         std.log.info("Expr: {s}", .{expr});
     }
 

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -7,6 +7,7 @@ const ExitStatus = @import("main.zig").ExitStatus;
 const Scanner = @import("scanner.zig").Scanner;
 const Token = @import("token.zig").Token;
 const TT = @import("token.zig").TokenType;
+const Parser = @import("parser.zig").Parser;
 
 const str = []const u8;
 
@@ -87,13 +88,16 @@ pub const Lexer = struct {
     fn run(self: Self, source: str) !void {
         var scanner = Scanner.init(self.allocator, source);
         defer scanner.deinit();
+        std.log.info("Source: {s}", .{source});
 
         const tokens = try scanner.scanTokens();
-        for (tokens.items) |token| {
-            std.log.info("{s}", .{token});
-        } else {
-            std.log.debug("End of tokens.", .{});
-        }
+        std.log.info("Tokens: {s}", .{tokens.items});
+        var parser = Parser.init(self.allocator, tokens);
+        defer parser.deinit();
+        const expr = try parser.parse();
+
+        std.log.info("Before expr.", .{});
+        std.log.info("Expr: {s}", .{expr});
     }
 
     pub fn handleError(line_num: usize, source: str) void {

--- a/src/lexer.zig
+++ b/src/lexer.zig
@@ -5,6 +5,8 @@ const Allocator = std.mem.Allocator;
 
 const ExitStatus = @import("main.zig").ExitStatus;
 const Scanner = @import("scanner.zig").Scanner;
+const Token = @import("token.zig").Token;
+const TT = @import("token.zig").TokenType;
 
 const str = []const u8;
 
@@ -94,8 +96,20 @@ pub const Lexer = struct {
         }
     }
 
-    pub fn handle_error(line_num: usize, source: str) void {
+    pub fn handleError(line_num: usize, source: str) void {
         report(line_num, "", source);
+    }
+
+    pub fn handleTokenError(token: Token, msg: str) void {
+        if (token.tokenType == TT.EOF) {
+            report(token.line, " at end", msg);
+        } else {
+            var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+            defer arena.deinit();
+
+            const where: str = std.fmt.allocPrint(arena.allocator(), " at '{s}'", .{token.lexeme}) catch unreachable;
+            report(token.line, where, msg);
+        }
     }
 
     fn report(line_num: usize, where: str, source: str) void {
@@ -157,7 +171,7 @@ test "run method should parse" {
 test "error method should return void on success" {
     const line_num = 1;
     const source = "asdf 1234 efghi";
-    try std.testing.expect(@TypeOf(Lexer.handle_error(line_num, source)) == void);
+    try std.testing.expect(@TypeOf(Lexer.handleError(line_num, source)) == void);
 }
 
 test "report method should return void on success" {

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -98,14 +98,7 @@ const Expr = union(ExprType) {
     pub fn format(self: *const Expr, comptime fmt: str, options: std.fmt.FormatOptions, writer: anytype) !void {
         _ = fmt;
         _ = options;
-        //try writer.print("{*}", .{self});
 
-        //switch (self.*) {
-        //    .Binary => try writer.print("BINARY", .{}),
-        //    .Unary => try writer.print("UNARY", .{}),
-        //    .Literal => try writer.print("LITERAL", .{}),
-        //    .Grouping => try writer.print("GROUPING", .{}),
-        //}
         switch (self.*) {
             .Binary => |b| try writer.print("({s} {s} {s})", .{ b.operator.lexeme, b.left.*, b.right.* }),
             .Unary => |u| try writer.print("({s} {s})", .{ u.operator.lexeme, u.right.* }),
@@ -201,10 +194,7 @@ pub const Parser = struct {
             std.log.info("Right: {s}", .{right});
             std.log.info("Current: {d}", .{self.current});
             std.log.info("Peek: {s}", .{self.peek()});
-            const termExpr = self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
-            //const termExpr = self.createExpr(Expr.initBinary(operator, expr, right));
-            //std.log.info("Expr2: {}", .{termExpr});
-            return termExpr;
+            return self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
         }
 
         return expr;
@@ -229,9 +219,7 @@ pub const Parser = struct {
             return self.createExpr(Unary{ .operator = operator, .right = right});
         }
 
-        const expr = try self.primary();
-        //std.log.info("Unary expr: {s}", .{expr});
-        return expr;
+        return try self.primary();
     }
 
     fn primary(self: *Parser) ParseError!*Expr {
@@ -240,10 +228,7 @@ pub const Parser = struct {
         if (self.match(.{TT.NIL})) return self.createExpr(Literal{ .value = Value{ .Nil = {} }});
 
         if (self.match(.{ TT.NUMBER, TT.STRING })) {
-            const expr = self.createExpr(Literal{ .value = self.previous().literal });
-            //std.log.info("Num/String: {s}", .{expr});
-            //std.log.info("Self.previous: {?}", .{self.previous().literal});
-            return expr;
+            return self.createExpr(Literal{ .value = self.previous().literal });
         }
 
         if (self.match(.{TT.LEFT_PAREN})) {
@@ -364,7 +349,6 @@ test "Parser success" {
     var parser = Parser.init(std.testing.allocator, tokens);
     defer parser.deinit();
     const expr = try parser.parse();
-    //std.log.info("Test: {s}", .{expr});
     const expected: str = "(+ 1 1)";
     try std.testing.expect(testExprMatchesExpected(expected, expr));
 }

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1,8 +1,50 @@
 const std = @import("std");
 const Token = @import("token.zig").Token;
+const Value = @import("token.zig").Value;
+const Lexer = @import("lexer.zig").Lexer;
 const TT = @import("token.zig").TokenType;
+const ArrayList = std.ArrayList;
 
 const str = []const u8;
+
+// It would be cool to figure out a way to generate the structs used in the syntax tree from a file
+// at comptime. There is a way to generate structs at comptime, but I don't know of a way to
+// dynamically set the name of the structs or if that would make sense. I might need to
+// generate a map of the struct name to the configuration and set each named struct by calling
+// another function to dynamicallly create the struct based on the input configuration.
+// I may also want to add the format string to the configuration as well and also look at dynamically
+// adding all possible types to the ExprType struct at comptime as well as generating the format function
+// switch prongs based on the dynamic tagged enum value and format string.
+fn createStructs() str {
+    const grammar = @embedFile("zlox.grammar");
+    var lineIt = std.mem.splitSequence(u8, grammar, "\n");
+    while (lineIt.next()) |line| {
+        const separatorIndex = std.mem.indexOf(u8, line, ":");
+
+        if (separatorIndex) |i| {
+            const name = std.mem.trim(u8, line[0..i], " \t");
+            const fields = std.mem.trim(u8, line[(i + 1)..], " \t\n\r");
+            std.debug.print("it.next(): Name: {s}; Fields: {s}\n", .{ name, fields });
+
+            var fieldIt = std.mem.splitSequence(u8, fields, ", ");
+            while (fieldIt.next()) |field| {
+                const trimmedField = std.mem.trim(u8, field, " \t\n\r");
+                std.debug.print("Field: {s}\n", .{trimmedField});
+            }
+        }
+    }
+    return grammar;
+}
+//_ = createStructs();
+
+const Type = @Type(.{
+    .Struct = .{
+        .layout = .Auto,
+        .fields = &[_]std.builtin.TypeInfo.StructField{},
+        .decls = &[_]std.builtin.TypeInfo.Declaration{},
+        .is_tuple = false,
+    },
+});
 
 const Binary = struct {
     left: *const Expr,
@@ -16,7 +58,7 @@ const Unary = struct {
 };
 
 const Literal = struct {
-    value: str = "nil",
+    value: ?Value = null,
 };
 
 const Grouping = struct {
@@ -45,24 +87,236 @@ const Expr = union(ExprType) {
         switch (self) {
             .Binary => |b| try writer.print("({s} {s} {s})", .{ b.operator.lexeme, b.left, b.right }),
             .Unary => |u| try writer.print("({s} {s})", .{ u.operator.lexeme, u.right }),
-            .Literal => |l| try writer.print("{s}", .{l.value}),
+            .Literal => |l| try writer.print("{?}", .{l.value}),
             .Grouping => |g| try writer.print("(group {s})", .{g.expression}),
         }
     }
 };
 
+const Parser = struct {
+    const Self = @This();
+
+    tokens: ArrayList(Token),
+    current: usize = 0,
+
+    pub fn init(tokens: ArrayList(Token)) Self {
+        return Self{
+            .tokens = tokens,
+        };
+    }
+
+    pub fn parse(self: *Self) ParseError!Expr {
+        std.debug.print("{s}", .{self.tokens.items});
+        const expr = self.expression();
+        std.debug.print("{any}", .{expr});
+        return expr;
+    }
+
+    fn expression(self: *Self) ParseError!Expr {
+        return try self.equality();
+    }
+
+    fn equality(self: *Self) ParseError!Expr {
+        var expr = try self.comparison();
+
+        while (self.match(.{ TT.BANG_EQUAL, TT.EQUAL_EQUAL })) {
+            const operator: Token = self.previous();
+            const right = try self.comparison();
+            expr = Expr{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+        }
+
+        return expr;
+    }
+
+    fn comparison(self: *Self) ParseError!Expr {
+        var expr = try self.term();
+
+        while (self.match(.{
+            TT.GREATER, TT.GREATER_EQUAL, TT.LESS, TT.LESS_EQUAL,
+        })) {
+            const operator: Token = self.previous();
+            var right = try self.term();
+            expr = .{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+        }
+
+        return expr;
+    }
+
+    fn term(self: *Self) ParseError!Expr {
+        var expr = try self.factor();
+
+        while (self.match(.{ TT.MINUS, TT.PLUS })) {
+            const operator: Token = self.previous();
+            var right = try self.factor();
+            expr = .{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+        }
+
+        return expr;
+    }
+
+    fn factor(self: *Self) ParseError!Expr {
+        var expr = try self.unary();
+
+        while (self.match(.{ TT.SLASH, TT.STAR })) {
+            const operator: Token = self.previous();
+            const right = try self.unary();
+            expr = .{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+        }
+
+        return expr;
+    }
+
+    fn unary(self: *Self) ParseError!Expr {
+        if (self.match(.{ TT.BANG, TT.MINUS })) {
+            const operator: Token = self.previous();
+            var right = try self.unary();
+            return Expr{ .Unary = .{ .operator = operator, .right = &right } };
+        }
+
+        return try self.primary();
+    }
+
+    fn primary(self: *Self) ParseError!Expr {
+        if (self.match(.{TT.FALSE})) return .{ .Literal = .{ .value = .{ .Bool = false } } };
+        if (self.match(.{TT.TRUE})) return .{ .Literal = .{ .value = .{ .Bool = true } } };
+        if (self.match(.{TT.NIL})) return .{ .Literal = .{ .value = .{ .Nil = {} } } };
+
+        if (self.match(.{ TT.NUMBER, TT.STRING })) return .{ .Literal = .{ .value = self.previous().literal } };
+
+        if (self.match(.{TT.LEFT_PAREN})) {
+            var expr = try self.expression();
+            _ = try self.consume(TT.RIGHT_PAREN, "Expect ')' after expression.", ParseError.MissingParens);
+            return Expr{ .Grouping = .{ .expression = &expr } };
+        }
+
+        _ = try Parser.handleError(self.peek(), "Expect expression.", ParseError.NoExpression);
+        return ParseError.NoExpression;
+    }
+
+    fn consume(self: *Self, tokenType: TT, msg: str, err: ParseError) !Token {
+        if (self.check(tokenType)) return self.advance();
+        _ = try Parser.handleError(self.peek(), msg, err);
+        return err;
+    }
+
+    fn handleError(token: Token, msg: str, err: ParseError) ParseError!void {
+        Lexer.handleTokenError(token, msg);
+        return err;
+    }
+
+    fn match(self: *Self, types: anytype) bool {
+        inline for (types) |tokenType| {
+            if (self.check(tokenType)) {
+                _ = self.advance();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    fn check(self: Self, tokenType: TT) bool {
+        if (self.isAtEnd()) return false;
+        return self.peek().tokenType == tokenType;
+    }
+
+    fn advance(self: *Self) Token {
+        if (!self.isAtEnd()) self.current += 1;
+        return self.previous();
+    }
+
+    fn isAtEnd(self: Self) bool {
+        return self.peek().tokenType == TT.EOF;
+    }
+
+    fn peek(self: Self) Token {
+        return self.tokens.items[self.current];
+    }
+
+    fn previous(self: Self) Token {
+        return self.tokens.items[self.current - 1];
+    }
+
+    fn synchronize(self: Self) void {
+        _ = self.advance();
+
+        while (!self.isAtEnd()) {
+            if (self.previous().tokenType == TT.SEMICOLON) return;
+
+            switch (self.peek().tokenType) {
+                .CLASS,
+                .FUN,
+                .VAR,
+                .FOR,
+                .IF,
+                .WHILE,
+                .PRINT,
+                .RETURN,
+                => return,
+                else => {},
+            }
+        }
+
+        _ = self.advance();
+    }
+};
+
+const ParseError = error{
+    MissingParens,
+    NoExpression,
+};
+
+test "Parser.init()" {
+    var tokens = ArrayList(Token).init(std.testing.allocator);
+    defer tokens.deinit();
+    try tokens.append(Token.init(TT.PLUS, "+", null, 1));
+
+    const parser = Parser.init(tokens);
+
+    try std.testing.expect(@TypeOf(parser) == Parser);
+    try std.testing.expectEqual(parser.tokens.items.len, 1);
+    try std.testing.expectEqual(parser.current, 0);
+}
+
+test "Parse error no expression" {
+    var tokens = ArrayList(Token).init(std.testing.allocator);
+    defer tokens.deinit();
+    try tokens.append(Token.init(TT.PLUS, "+", null, 1));
+
+    var parser = Parser.init(tokens);
+    try std.testing.expectError(ParseError.NoExpression, parser.parse());
+}
+
+test "Parser success" {
+    var tokens = ArrayList(Token).init(std.testing.allocator);
+    defer tokens.deinit();
+    try tokens.append(Token.init(TT.NUMBER, "1", null, 1));
+    try tokens.append(Token.init(TT.PLUS, "+", null, 1));
+    try tokens.append(Token.init(TT.NUMBER, "1", null, 1));
+    try tokens.append(Token.init(TT.EOF, "", null, 1));
+
+    var parser = Parser.init(tokens);
+    const expr = try parser.parse();
+    const expected: str = "(+ 1 1)";
+    try std.testing.expect(testExprMatchesExpected(expected, expr));
+}
+
+//test "Read grammar file" {
+//    std.debug.print("{s}", .{createStructs()});
+//}
+
 test "Expr: 1" {
-    const expr = Expr{ .Literal = Literal{ .value = "1" } };
+    const expr = Expr{ .Literal = Literal{ .value = .{ .Number = 1.0 } } };
     try std.testing.expect(testExprMatchesExpected("1", expr));
 }
 
 test "Expr: (+ 1 2)" {
-    const expr = Expr{ .Binary = .{ .left = &Expr{ .Literal = .{ .value = "1" } }, .operator = Token.init(TT.PLUS, "+", 1), .right = &Expr{ .Literal = .{ .value = "2" } } } };
+    const expr = Expr{ .Binary = .{ .left = &Expr{ .Literal = .{ .value = .{ .Number = 1.0 } } }, .operator = Token.init(TT.PLUS, "+", null, 1), .right = &Expr{ .Literal = .{ .value = .{ .Number = 2.0 } } } } };
     try std.testing.expect(testExprMatchesExpected("(+ 1 2)", expr));
 }
 
 test "Expr: (* (- 123) (group 45.67))" {
-    const expr = Expr{ .Binary = Binary{ .left = &Expr{ .Unary = .{ .operator = Token.init(TT.MINUS, "-", 1), .right = &Expr{ .Literal = .{ .value = "123" } } } }, .operator = Token.init(TT.STAR, "*", 1), .right = &Expr{ .Grouping = .{ .expression = &Expr{ .Literal = .{ .value = "45.67" } } } } } };
+    const expr = Expr{ .Binary = Binary{ .left = &Expr{ .Unary = .{ .operator = Token.init(TT.MINUS, "-", null, 1), .right = &Expr{ .Literal = .{ .value = .{ .Number = 123.0 } } } } }, .operator = Token.init(TT.STAR, "*", null, 1), .right = &Expr{ .Grouping = .{ .expression = &Expr{ .Literal = .{ .value = .{ .Number = 45.67 } } } } } } };
     try std.testing.expect(testExprMatchesExpected("(* (- 123) (group 45.67))", expr));
 }
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -160,7 +160,6 @@ pub const Parser = struct {
             return self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
         }
 
-        std.log.info("Equality: {s}", .{expr});
         return expr;
     }
 
@@ -175,9 +174,6 @@ pub const Parser = struct {
             return self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
         }
 
-        std.log.info("Comparison: ", .{});
-        std.log.info("Comparison: {}", .{expr});
-        std.log.info("Comparison: {s}", .{expr});
         return expr;
     }
 
@@ -186,14 +182,7 @@ pub const Parser = struct {
 
         while (self.match(.{ TT.MINUS, TT.PLUS })) {
             const operator: Token = self.previous();
-            std.log.info("Operator: {s}", .{operator});
-            std.log.info("Expr before: {s}", .{expr});
-            std.log.info("Current: {d}", .{self.current});
-            std.log.info("Peek: {s}", .{self.peek()});
             const right = try self.factor();
-            std.log.info("Right: {s}", .{right});
-            std.log.info("Current: {d}", .{self.current});
-            std.log.info("Peek: {s}", .{self.peek()});
             return self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
         }
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -3,15 +3,16 @@ const Token = @import("token.zig").Token;
 const Value = @import("token.zig").Value;
 const Lexer = @import("lexer.zig").Lexer;
 const TT = @import("token.zig").TokenType;
-const ArrayList = std.ArrayList;
 
+const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
 const str = []const u8;
 
 // It would be cool to figure out a way to generate the structs used in the syntax tree from a file
 // at comptime. There is a way to generate structs at comptime, but I don't know of a way to
 // dynamically set the name of the structs or if that would make sense. I might need to
 // generate a map of the struct name to the configuration and set each named struct by calling
-// another function to dynamicallly create the struct based on the input configuration.
+// another function to dynamically create the struct based on the input configuration.
 // I may also want to add the format string to the configuration as well and also look at dynamically
 // adding all possible types to the ExprType struct at comptime as well as generating the format function
 // switch prongs based on the dynamic tagged enum value and format string.
@@ -73,127 +74,189 @@ const ExprType = enum {
 };
 
 const Expr = union(ExprType) {
-    const Self = @This();
-
     Binary: Binary,
     Unary: Unary,
     Literal: Literal,
     Grouping: Grouping,
 
-    pub fn format(self: Self, comptime fmt: str, options: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn initBinary(left: *Expr, operator: Token, right: *Expr) Expr {
+        return Expr { .Binary = Binary{ .left = left, .operator = operator, .right = right }};
+    }
+
+    pub fn initUnary(operator: Token, right: *Expr) Expr {
+        return Expr { .Unary = Unary{ .operator = operator, .right = right }};
+    }
+
+    pub fn initLiteral(value: ?Value) Expr {
+        return Expr { .Literal = Literal{ .value = value }};
+    }
+
+    pub fn initGrouping(expression: *Expr) Expr {
+        return Expr { .Grouping = Grouping{ .expression = expression }};
+    }
+
+    pub fn format(self: *const Expr, comptime fmt: str, options: std.fmt.FormatOptions, writer: anytype) !void {
         _ = fmt;
         _ = options;
+        //try writer.print("{*}", .{self});
 
-        switch (self) {
-            .Binary => |b| try writer.print("({s} {s} {s})", .{ b.operator.lexeme, b.left, b.right }),
-            .Unary => |u| try writer.print("({s} {s})", .{ u.operator.lexeme, u.right }),
+        //switch (self.*) {
+        //    .Binary => try writer.print("BINARY", .{}),
+        //    .Unary => try writer.print("UNARY", .{}),
+        //    .Literal => try writer.print("LITERAL", .{}),
+        //    .Grouping => try writer.print("GROUPING", .{}),
+        //}
+        switch (self.*) {
+            .Binary => |b| try writer.print("({s} {s} {s})", .{ b.operator.lexeme, b.left.*, b.right.* }),
+            .Unary => |u| try writer.print("({s} {s})", .{ u.operator.lexeme, u.right.* }),
             .Literal => |l| try writer.print("{?}", .{l.value}),
             .Grouping => |g| try writer.print("(group {s})", .{g.expression}),
         }
     }
 };
 
-const Parser = struct {
-    const Self = @This();
-
+pub const Parser = struct {
     tokens: ArrayList(Token),
     current: usize = 0,
+    allocator: Allocator,
+    nodes: ArrayList(*Expr),
 
-    pub fn init(tokens: ArrayList(Token)) Self {
-        return Self{
+    pub fn init(allocator: Allocator, tokens: ArrayList(Token)) Parser {
+        return Parser{
+            .allocator = allocator,
             .tokens = tokens,
+            .nodes = ArrayList(*Expr).init(allocator),
         };
     }
 
-    pub fn parse(self: *Self) ParseError!Expr {
-        std.debug.print("{s}", .{self.tokens.items});
-        const expr = self.expression();
-        std.debug.print("{any}", .{expr});
+    pub fn deinit(self: *Parser) void {
+        while (self.nodes.popOrNull()) |expr| {
+            self.allocator.destroy(expr);
+        }
+        self.nodes.deinit();
+    }
+
+    fn createExpr(self: *Parser, inner: anytype) ParseError!*Expr {
+        const expr = try self.allocator.create(Expr);
+        expr.* = switch (@TypeOf(inner)) {
+            Binary => Expr{ .Binary = inner },
+            Unary => Expr{ .Unary = inner },
+            Literal => Expr{ .Literal = inner },
+            Grouping => Expr{ .Grouping = inner },
+            else => return ParseError.NoExpression,
+        };
+        _ = try self.nodes.append(expr);
         return expr;
     }
 
-    fn expression(self: *Self) ParseError!Expr {
+    pub fn parse(self: *Parser) ParseError!Expr {
+        const expr =  try self.expression();
+        return expr.*;
+    }
+
+    fn expression(self: *Parser) ParseError!*Expr {
         return try self.equality();
     }
 
-    fn equality(self: *Self) ParseError!Expr {
-        var expr = try self.comparison();
+    fn equality(self: *Parser) ParseError!*Expr {
+        const expr = try self.comparison();
 
         while (self.match(.{ TT.BANG_EQUAL, TT.EQUAL_EQUAL })) {
             const operator: Token = self.previous();
             const right = try self.comparison();
-            expr = Expr{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+            return self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
         }
 
+        std.log.info("Equality: {s}", .{expr});
         return expr;
     }
 
-    fn comparison(self: *Self) ParseError!Expr {
-        var expr = try self.term();
+    fn comparison(self: *Parser) ParseError!*Expr {
+        const expr = try self.term();
 
         while (self.match(.{
             TT.GREATER, TT.GREATER_EQUAL, TT.LESS, TT.LESS_EQUAL,
         })) {
             const operator: Token = self.previous();
-            var right = try self.term();
-            expr = .{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+            const right = try self.term();
+            return self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
         }
 
+        std.log.info("Comparison: ", .{});
+        std.log.info("Comparison: {}", .{expr});
+        std.log.info("Comparison: {s}", .{expr});
         return expr;
     }
 
-    fn term(self: *Self) ParseError!Expr {
-        var expr = try self.factor();
+    fn term(self: *Parser) ParseError!*Expr {
+        const expr = try self.factor();
 
         while (self.match(.{ TT.MINUS, TT.PLUS })) {
             const operator: Token = self.previous();
-            var right = try self.factor();
-            expr = .{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+            std.log.info("Operator: {s}", .{operator});
+            std.log.info("Expr before: {s}", .{expr});
+            std.log.info("Current: {d}", .{self.current});
+            std.log.info("Peek: {s}", .{self.peek()});
+            const right = try self.factor();
+            std.log.info("Right: {s}", .{right});
+            std.log.info("Current: {d}", .{self.current});
+            std.log.info("Peek: {s}", .{self.peek()});
+            const termExpr = self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
+            //const termExpr = self.createExpr(Expr.initBinary(operator, expr, right));
+            //std.log.info("Expr2: {}", .{termExpr});
+            return termExpr;
         }
 
         return expr;
     }
 
-    fn factor(self: *Self) ParseError!Expr {
-        var expr = try self.unary();
+    fn factor(self: *Parser) ParseError!*Expr {
+        const expr = try self.unary();
 
         while (self.match(.{ TT.SLASH, TT.STAR })) {
             const operator: Token = self.previous();
             const right = try self.unary();
-            expr = .{ .Binary = .{ .left = &expr, .operator = operator, .right = &right } };
+            return self.createExpr(Binary{ .left = expr, .operator = operator, .right = right});
         }
 
         return expr;
     }
 
-    fn unary(self: *Self) ParseError!Expr {
+    fn unary(self: *Parser) ParseError!*Expr {
         if (self.match(.{ TT.BANG, TT.MINUS })) {
             const operator: Token = self.previous();
-            var right = try self.unary();
-            return Expr{ .Unary = .{ .operator = operator, .right = &right } };
+            const right: *const Expr = try self.unary();
+            return self.createExpr(Unary{ .operator = operator, .right = right});
         }
 
-        return try self.primary();
+        const expr = try self.primary();
+        //std.log.info("Unary expr: {s}", .{expr});
+        return expr;
     }
 
-    fn primary(self: *Self) ParseError!Expr {
-        if (self.match(.{TT.FALSE})) return .{ .Literal = .{ .value = .{ .Bool = false } } };
-        if (self.match(.{TT.TRUE})) return .{ .Literal = .{ .value = .{ .Bool = true } } };
-        if (self.match(.{TT.NIL})) return .{ .Literal = .{ .value = .{ .Nil = {} } } };
+    fn primary(self: *Parser) ParseError!*Expr {
+        if (self.match(.{TT.FALSE})) return self.createExpr(Literal{ .value = Value{ .Bool = false }});
+        if (self.match(.{TT.TRUE})) return self.createExpr(Literal{ .value = Value{ .Bool = true }});
+        if (self.match(.{TT.NIL})) return self.createExpr(Literal{ .value = Value{ .Nil = {} }});
 
-        if (self.match(.{ TT.NUMBER, TT.STRING })) return .{ .Literal = .{ .value = self.previous().literal } };
+        if (self.match(.{ TT.NUMBER, TT.STRING })) {
+            const expr = self.createExpr(Literal{ .value = self.previous().literal });
+            //std.log.info("Num/String: {s}", .{expr});
+            //std.log.info("Self.previous: {?}", .{self.previous().literal});
+            return expr;
+        }
 
         if (self.match(.{TT.LEFT_PAREN})) {
-            var expr = try self.expression();
+            const expr = try self.expression();
             _ = try self.consume(TT.RIGHT_PAREN, "Expect ')' after expression.", ParseError.MissingParens);
-            return Expr{ .Grouping = .{ .expression = &expr } };
+            return self.createExpr(Grouping{ .expression = expr });
         }
 
         _ = try Parser.handleError(self.peek(), "Expect expression.", ParseError.NoExpression);
         return ParseError.NoExpression;
     }
 
-    fn consume(self: *Self, tokenType: TT, msg: str, err: ParseError) !Token {
+    fn consume(self: *Parser, tokenType: TT, msg: str, err: ParseError) !Token {
         if (self.check(tokenType)) return self.advance();
         _ = try Parser.handleError(self.peek(), msg, err);
         return err;
@@ -204,7 +267,7 @@ const Parser = struct {
         return err;
     }
 
-    fn match(self: *Self, types: anytype) bool {
+    fn match(self: *Parser, types: anytype) bool {
         inline for (types) |tokenType| {
             if (self.check(tokenType)) {
                 _ = self.advance();
@@ -215,29 +278,29 @@ const Parser = struct {
         return false;
     }
 
-    fn check(self: Self, tokenType: TT) bool {
+    fn check(self: Parser, tokenType: TT) bool {
         if (self.isAtEnd()) return false;
         return self.peek().tokenType == tokenType;
     }
 
-    fn advance(self: *Self) Token {
+    fn advance(self: *Parser) Token {
         if (!self.isAtEnd()) self.current += 1;
         return self.previous();
     }
 
-    fn isAtEnd(self: Self) bool {
+    fn isAtEnd(self: Parser) bool {
         return self.peek().tokenType == TT.EOF;
     }
 
-    fn peek(self: Self) Token {
+    fn peek(self: Parser) Token {
         return self.tokens.items[self.current];
     }
 
-    fn previous(self: Self) Token {
+    fn previous(self: Parser) Token {
         return self.tokens.items[self.current - 1];
     }
 
-    fn synchronize(self: Self) void {
+    fn synchronize(self: Parser) void {
         _ = self.advance();
 
         while (!self.isAtEnd()) {
@@ -264,6 +327,7 @@ const Parser = struct {
 const ParseError = error{
     MissingParens,
     NoExpression,
+    OutOfMemory,
 };
 
 test "Parser.init()" {
@@ -271,7 +335,8 @@ test "Parser.init()" {
     defer tokens.deinit();
     try tokens.append(Token.init(TT.PLUS, "+", null, 1));
 
-    const parser = Parser.init(tokens);
+    var parser = Parser.init(std.testing.allocator, tokens);
+    defer parser.deinit();
 
     try std.testing.expect(@TypeOf(parser) == Parser);
     try std.testing.expectEqual(parser.tokens.items.len, 1);
@@ -283,20 +348,23 @@ test "Parse error no expression" {
     defer tokens.deinit();
     try tokens.append(Token.init(TT.PLUS, "+", null, 1));
 
-    var parser = Parser.init(tokens);
+    var parser = Parser.init(std.testing.allocator, tokens);
+    defer parser.deinit();
     try std.testing.expectError(ParseError.NoExpression, parser.parse());
 }
 
 test "Parser success" {
     var tokens = ArrayList(Token).init(std.testing.allocator);
     defer tokens.deinit();
-    try tokens.append(Token.init(TT.NUMBER, "1", null, 1));
+    try tokens.append(Token.init(TT.NUMBER, "1", Value{ .Number = 1.0 }, 1));
     try tokens.append(Token.init(TT.PLUS, "+", null, 1));
-    try tokens.append(Token.init(TT.NUMBER, "1", null, 1));
+    try tokens.append(Token.init(TT.NUMBER, "1", Value{ .Number = 1.0 }, 1));
     try tokens.append(Token.init(TT.EOF, "", null, 1));
 
-    var parser = Parser.init(tokens);
+    var parser = Parser.init(std.testing.allocator, tokens);
+    defer parser.deinit();
     const expr = try parser.parse();
+    //std.log.info("Test: {s}", .{expr});
     const expected: str = "(+ 1 1)";
     try std.testing.expect(testExprMatchesExpected(expected, expr));
 }
@@ -322,6 +390,6 @@ test "Expr: (* (- 123) (group 45.67))" {
 
 // Helper method for checking if Expression matches expected string
 fn testExprMatchesExpected(comptime expected: str, expr: Expr) bool {
-    var tokenBuffer: [expected.len]u8 = undefined;
+    var tokenBuffer: [1000]u8 = undefined;
     return std.mem.eql(u8, std.fmt.bufPrint(&tokenBuffer, "{s}", .{expr}) catch "FAILED", expected);
 }

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -197,7 +197,11 @@ pub const Scanner = struct {
     }
 
     fn addTokenWithLiteral(self: *Self, tokenType: TT, literal: ?Value) !void {
-        const text = self.src[self.start..self.current];
+        var text: []const u8 = "";
+        if (!self.isAtEnd()) {
+            text = self.src[self.start..self.current];
+        }
+        std.log.info("TokenType: {s}; Len: {d}; Start: {d}; Current: {d}; Text: {s}", .{tokenType, self.src.len, self.start, self.current, text});
         try self.tokens.append(Token.init(tokenType, text, literal, self.line));
     }
 
@@ -252,6 +256,8 @@ test "scanToken" {
     try std.testing.expect(scanner.current == 2);
 
     try std.testing.expect(scanner.tokens.items.len == 2);
+    std.debug.print("**** items[0]: {s}", .{scanner.tokens.items[0].lexeme});
+    std.debug.print("**** items[1]: {s}", .{scanner.tokens.items[1].lexeme});
     try std.testing.expect(std.mem.eql(u8, scanner.tokens.items[0].lexeme, "("));
     try std.testing.expect(std.mem.eql(u8, scanner.tokens.items[1].lexeme, ")"));
 }

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -201,7 +201,7 @@ pub const Scanner = struct {
         if (tokenType != TT.EOF and self.current <= self.src.len) {
             text = self.src[self.start..self.current];
         }
-        std.log.info("TokenType: {s}; Len: {d}; Start: {d}; Current: {d}; Text: {d}", .{tokenType, self.src.len, self.start, self.current, text});
+        //std.log.info("TokenType: {s}; Len: {d}; Start: {d}; Current: {d}; Text: {d}", .{tokenType, self.src.len, self.start, self.current, text});
         try self.tokens.append(Token.init(tokenType, text, literal, self.line));
     }
 

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -201,7 +201,7 @@ pub const Scanner = struct {
         if (self.current <= self.src.len) {
             text = self.src[self.start..self.current];
         }
-        std.log.info("TokenType: {s}; Len: {d}; Start: {d}; Current: {d}; Text: {s}", .{tokenType, self.src.len, self.start, self.current, text});
+        std.log.info("TokenType: {s}; Len: {d}; Start: {d}; Current: {d}; Text: {d}", .{tokenType, self.src.len, self.start, self.current, text});
         try self.tokens.append(Token.init(tokenType, text, literal, self.line));
     }
 

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -198,7 +198,7 @@ pub const Scanner = struct {
 
     fn addTokenWithLiteral(self: *Self, tokenType: TT, literal: ?Value) !void {
         var text: []const u8 = "";
-        if (self.current <= self.src.len) {
+        if (tokenType != TT.EOF and self.current <= self.src.len) {
             text = self.src[self.start..self.current];
         }
         std.log.info("TokenType: {s}; Len: {d}; Start: {d}; Current: {d}; Text: {d}", .{tokenType, self.src.len, self.start, self.current, text});

--- a/src/scanner.zig
+++ b/src/scanner.zig
@@ -198,7 +198,7 @@ pub const Scanner = struct {
 
     fn addTokenWithLiteral(self: *Self, tokenType: TT, literal: ?Value) !void {
         var text: []const u8 = "";
-        if (!self.isAtEnd()) {
+        if (self.current <= self.src.len) {
             text = self.src[self.start..self.current];
         }
         std.log.info("TokenType: {s}; Len: {d}; Start: {d}; Current: {d}; Text: {s}", .{tokenType, self.src.len, self.start, self.current, text});
@@ -231,11 +231,11 @@ test "scanTokens" {
     const tokens = try scanner.scanTokens();
 
     try std.testing.expect(tokens.items.len > 0);
+    try std.testing.expect(tokens.items.len == 6);
 
-    //for (scanner.tokens.items) |token| {
-    //    std.debug.print("{s}", .{token});
-    //    try std.testing.expect(std.mem.eql(u8, token, undefined));
-    //}
+    for (scanner.tokens.items) |token| {
+        try std.testing.expect(token.tokenType == TT.THIS or token.tokenType == TT.IDENTIFIER or token.tokenType == TT.EOF);
+    }
 }
 
 test "scanToken" {
@@ -256,8 +256,6 @@ test "scanToken" {
     try std.testing.expect(scanner.current == 2);
 
     try std.testing.expect(scanner.tokens.items.len == 2);
-    std.debug.print("**** items[0]: {s}", .{scanner.tokens.items[0].lexeme});
-    std.debug.print("**** items[1]: {s}", .{scanner.tokens.items[1].lexeme});
     try std.testing.expect(std.mem.eql(u8, scanner.tokens.items[0].lexeme, "("));
     try std.testing.expect(std.mem.eql(u8, scanner.tokens.items[1].lexeme, ")"));
 }

--- a/src/token.zig
+++ b/src/token.zig
@@ -50,21 +50,13 @@ pub const TokenType = enum {
     WHILE,
 
     EOF,
+
+    pub fn format(self: TokenType, comptime fmt: str, options: std.fmt.FormatOptions, writer: anytype) !void {
+        _ = fmt;
+        _ = options;
+        try writer.print("{s}", .{@tagName(self)});
+    }
 };
-
-pub fn Literal(comptime T: type) type {
-    const Self = @This();
-
-    return struct {
-        val: T,
-
-        pub fn init(val: T) Self {
-            return Self{
-                .val = val,
-            };
-        }
-    };
-}
 
 pub const Value = union(enum) {
     Bool: bool,
@@ -133,6 +125,36 @@ test "print the token" {
     );
 
     const expected: str = "WHILE while null";
+    var tokenBuffer: [expected.len]u8 = undefined;
+
+    _ = try std.fmt.bufPrint(&tokenBuffer, "{s}", .{token});
+    try std.testing.expect(std.mem.eql(u8, &tokenBuffer, expected));
+}
+
+test "print a number" {
+    const token = Token.init(
+        TokenType.NUMBER,
+        "1",
+        Value{ .Number = @as(f64, 1) },
+        2,
+    );
+
+    const expected: str = "NUMBER 1 1";
+    var tokenBuffer: [expected.len]u8 = undefined;
+
+    _ = try std.fmt.bufPrint(&tokenBuffer, "{s}", .{token});
+    try std.testing.expect(std.mem.eql(u8, &tokenBuffer, expected));
+}
+
+test "print a string" {
+    const token = Token.init(
+        TokenType.STRING,
+        "this is a string",
+        Value{ .String = "this is a string" },
+        3,
+    );
+
+    const expected: str = "STRING this is a string this is a string";
     var tokenBuffer: [expected.len]u8 = undefined;
 
     _ = try std.fmt.bufPrint(&tokenBuffer, "{s}", .{token});

--- a/src/zlox.grammar
+++ b/src/zlox.grammar
@@ -1,0 +1,4 @@
+Binary 		: Expr left, Token operator, Expr right
+Grouping	: Expr expression
+Literal		: str value
+Unary		: Token operator, Expr right


### PR DESCRIPTION
Adding chapter 6 changes. Recursive descent works in Zig well enough, but we must use an allocator to allocate memory for each expression tree node as we return from each function. Without using an allocator, the stack pointers get discarded at the end of the function call due to the stack frame being popped off so the inner pointers to child expression nodes get lost. It took some time to figure out how to manage the memory for the expression without passing an allocator to the expression struct but keeping it in the parser struct and then utilizing a `deinit` method that will free each expression that is generated and saved in a reference ArrayList. The ArrayList functions like a stack where each node that is created on the heap will be pushed (using `.append(expr)`) to the end of the list and in the `deinit()` method the ArrayList will pop each expression pointer off the end of the list and free the pointer until the list is empty.